### PR TITLE
Compatibility with std ranges

### DIFF
--- a/include/range/v3/range/concepts.hpp
+++ b/include/range/v3/range/concepts.hpp
@@ -44,6 +44,10 @@
 
 #include <range/v3/detail/prologue.hpp>
 
+#ifdef RANGE_V3_COMBINE_WITH_STD
+#include <ranges>
+#endif
+
 namespace ranges
 {
     /// \addtogroup group-range-concepts
@@ -223,9 +227,15 @@ namespace ranges
     /// \endcond
 
     // Specialize this if the default is wrong.
+#ifndef RANGE_V3_COMBINE_WITH_STD
     template<typename T>
     RANGES_INLINE_VAR constexpr bool enable_view =
         ext::enable_view<T>::value;
+#else
+    template<typename T>
+    RANGES_INLINE_VAR constexpr bool enable_view =
+        ext::enable_view<T>::value || std::ranges::enable_view<T>;
+#endif
 
 #if defined(__cpp_lib_string_view) && __cpp_lib_string_view >= 201603L
     template<typename Char, typename Traits>

--- a/include/range/v3/range_fwd.hpp
+++ b/include/range/v3/range_fwd.hpp
@@ -26,6 +26,10 @@
 #include <range/v3/utility/static_const.hpp>
 #include <range/v3/version.hpp>
 
+#ifdef RANGE_V3_COMBINE_WITH_STD
+#include <ranges>
+#endif
+
 /// \defgroup group-iterator Iterator
 /// Iterator functionality
 
@@ -178,8 +182,13 @@ namespace ranges
     template<typename T>
     struct incrementable_traits;
 
+#ifdef RANGE_V3_COMBINE_WITH_STD
+    struct view_base : std::ranges::view_base
+    {};
+#else
     struct view_base
     {};
+#endif
 
     /// \cond
     namespace detail

--- a/include/range/v3/view/interface.hpp
+++ b/include/range/v3/view/interface.hpp
@@ -29,9 +29,6 @@
 #include <range/v3/range/traits.hpp>
 
 #include <range/v3/detail/prologue.hpp>
-#ifdef RANGE_V3_COMBINE_WITH_STD
-#include <ranges>
-#endif
 
 #if defined(RANGES_WORKAROUND_GCC_91525)
 #define CPP_template_gcc_workaround CPP_template_sfinae
@@ -512,13 +509,6 @@ namespace ranges
     }
     /// @}
 } // namespace ranges
-
-#ifdef RANGE_V3_COMBINE_WITH_STD
-template<typename Derived, ::ranges::cardinality Cardinality /* = finite*/>
-inline constexpr bool std::ranges::enable_view<::ranges::view_interface<Derived, Cardinality>> = true;
-#endif
-
-
 
 #include <range/v3/detail/epilogue.hpp>
 

--- a/include/range/v3/view/interface.hpp
+++ b/include/range/v3/view/interface.hpp
@@ -29,6 +29,9 @@
 #include <range/v3/range/traits.hpp>
 
 #include <range/v3/detail/prologue.hpp>
+#ifdef RANGE_V3_COMBINE_WITH_STD
+#include <ranges>
+#endif
 
 #if defined(RANGES_WORKAROUND_GCC_91525)
 #define CPP_template_gcc_workaround CPP_template_sfinae
@@ -509,6 +512,13 @@ namespace ranges
     }
     /// @}
 } // namespace ranges
+
+#ifdef RANGE_V3_COMBINE_WITH_STD
+template<typename Derived, ::ranges::cardinality Cardinality /* = finite*/>
+inline constexpr bool std::ranges::enable_view<::ranges::view_interface<Derived, Cardinality>> = true;
+#endif
+
+
 
 #include <range/v3/detail/epilogue.hpp>
 


### PR DESCRIPTION
When `range-v3` is compiled with the macro `RANGE_V3_COMBINE_WITH_STD` defined, then
* Each `ranges::view` also fulfills the `std::ranges::view` concept.
* Each `std::ranges::view` also fulfills the `ranges::view` concept.