### PR TITLE
Make `views::cache1::equal` SFINAE-friendly

### DIFF
--- a/include/range/v3/view/cache1.hpp
+++ b/include/range/v3/view/cache1.hpp
@@ -107,7 +107,10 @@ namespace ranges
                 ++current_;
                 parent_->dirty_ = true;
             }
-            bool equal(cursor const & that) const
+            CPP_member
+
+           auto equal(cursor const & that) const //
+              -> CPP_ret(bool)(requires sentinel_for<iterator_t<Rng>, iterator_t<Rng>>)
             {
                 return current_ == that.current_;
             }


### PR DESCRIPTION
The iterators of the `cache1_view` previously unconditionally had an `equal` function which was ill-formed, if the underlying view did not model `common_range`. This is now addressed by adding a proper `SFINAE/concepts` constraint on that function.